### PR TITLE
fix: specify correct entry point for Railway deployment - Explicitly …

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,7 +1,9 @@
 [build]
 builder = "nixpacks"
+buildCommand = "go build -o main cmd/server/main.go"
 
 [deploy]
+startCommand = "./main"
 healthcheckPath = "/healthz"
 restartPolicyType = "on_failure"
 


### PR DESCRIPTION
…build cmd/server/main.go instead of cmd/migrate - Set startCommand to run the server binary - Prevent Nixpacks from auto-selecting wrong entry point