### PR TITLE
fix: build migration binary for pre-deploy command - Build both serve…

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "nixpacks"
-buildCommand = "go build -o main cmd/server/main.go"
+buildCommand = "go build -o main cmd/server/main.go && go build -o migrate cmd/migrate/main.go"
 
 [deploy]
 startCommand = "./main"


### PR DESCRIPTION
…r and migration binaries during build phase - Allows pre-deploy command to use compiled migration binary