### PR TITLE
fix: Add missing authentication requirement to GET posts endpoint in …

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -235,6 +235,8 @@ paths:
       description: Get a paginated list of posts for a specific newsletter
       tags:
         - Posts
+      security:
+        - BearerAuth: []
       parameters:
         - name: newsletterID
           in: path
@@ -265,6 +267,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PostListResponse'
+        '401':
+          description: Unauthorized
         '404':
           description: Newsletter not found
 


### PR DESCRIPTION
…Swagger docs - Add security requirement (BearerAuth) to GET /api/newsletters/{newsletterID}/posts endpoint - Add missing 401 Unauthorized response to match other protected endpoints - Resolves discrepancy between actual API implementation (which requires auth) and Swagger documentation - Ensures Swagger UI correctly displays lock icon for this protected endpoint