### PR TITLE
Add Swagger UI integration via public service - Add /swagger redirect…

### DIFF
--- a/internal/layers/router/router.go
+++ b/internal/layers/router/router.go
@@ -62,11 +62,17 @@ func NewRouter(deps RouterDependencies) *chi.Mux {
 		http.ServeFile(w, r, "docs/openapi.yaml")
 	})
 
-	// Redirect to Swagger UI with our OpenAPI spec
+	// Serve Swagger UI
 	r.Get("/swagger", func(w http.ResponseWriter, r *http.Request) {
-		specURL := "https://strv-vse-go-newsletter-production.up.railway.app/openapi.yaml"
-		swaggerURL := "https://petstore.swagger.io/?url=" + specURL
-		http.Redirect(w, r, swaggerURL, http.StatusFound)
+		http.Redirect(w, r, "/swagger/", http.StatusFound)
+	})
+	
+	r.Get("/swagger/", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "static/swagger/index.html")
+	})
+	
+	r.Get("/swagger/index.html", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "static/swagger/index.html")
 	})
 
 	// API routes

--- a/internal/layers/router/router.go
+++ b/internal/layers/router/router.go
@@ -57,7 +57,16 @@ func NewRouter(deps RouterDependencies) *chi.Mux {
 
 	// Serve OpenAPI specification
 	r.Get("/openapi.yaml", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-yaml")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		http.ServeFile(w, r, "docs/openapi.yaml")
+	})
+
+	// Redirect to Swagger UI with our OpenAPI spec
+	r.Get("/swagger", func(w http.ResponseWriter, r *http.Request) {
+		specURL := "https://strv-vse-go-newsletter-production.up.railway.app/openapi.yaml"
+		swaggerURL := "https://petstore.swagger.io/?url=" + specURL
+		http.Redirect(w, r, swaggerURL, http.StatusFound)
 	})
 
 	// API routes

--- a/static/swagger/index.html
+++ b/static/swagger/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Newsletter API Documentation</title>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.10.5/swagger-ui.css" />
+    <style>
+        html {
+            box-sizing: border-box;
+            overflow: -moz-scrollbars-vertical;
+            overflow-y: scroll;
+        }
+        *, *:before, *:after {
+            box-sizing: inherit;
+        }
+        body {
+            margin:0;
+            background: #fafafa;
+        }
+        .swagger-ui .topbar { display: none; }
+    </style>
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5.10.5/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.10.5/swagger-ui-standalone-preset.js"></script>
+    <script>
+        window.onload = function() {
+            // Begin Swagger UI call region
+            const ui = SwaggerUIBundle({
+                url: '/openapi.yaml',
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [
+                    SwaggerUIBundle.presets.apis,
+                    SwaggerUIStandalonePreset
+                ],
+                plugins: [
+                    SwaggerUIBundle.plugins.DownloadUrl
+                ],
+                layout: "StandaloneLayout",
+                tryItOutEnabled: true,
+                supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+                onComplete: function() {
+                    console.log('Swagger UI loaded successfully');
+                },
+                onFailure: function(err) {
+                    console.error('Failed to load API spec:', err);
+                }
+            });
+            // End Swagger UI call region
+        };
+    </script>
+</body>
+</html> 


### PR DESCRIPTION
… to petstore.swagger.io with our OpenAPI spec - Add proper CORS headers to /openapi.yaml for external access - Add Content-Type header for better spec serving